### PR TITLE
Fix default password + verifications on port and password strings

### DIFF
--- a/incl/server/Server.h
+++ b/incl/server/Server.h
@@ -32,6 +32,7 @@
 
 # define DEFAULT_PORT "6667"
 # define DEFAULT_PASSWORD "password"
+# define SERVER_HOSTNAME "ft_irc.42.fr"
 # define MAX_CONNEXIONS 10
 
 class	Server {
@@ -48,7 +49,7 @@ class	Server {
 		// -- Getter --
 		Client* 				get_client(const int fd);
 		Client* 				get_client(std::string nick);
-		const std::string& 			get_password() const; 
+		const std::string& 		get_password() const;
 		std::map<int, Client>& 	get_client_list();
 		const std::string&      get_hostname() const;
 
@@ -59,6 +60,9 @@ class	Server {
 		int 	create_client();
 		void 	print_clients();
 
+		// -- Public static functions --
+		static bool		is_valid_port(const std::string& port);
+		static bool		is_valid_password(const std::string& password);
 
 		// --- Public attributes ---
 		bool	_started;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -14,14 +14,17 @@ int	main(int ac, char **av)
 		usage(av[0]);
 		exit(1);
 	}
-
+	if (!Server::is_valid_port(av[1])) {
+		std::cerr << "Invalid port number\n";
+		exit(2);
+	}
+	if (!Server::is_valid_password(av[2])) {
+		std::cerr << "Invalid password\n";
+		exit(3);
+	}
 	Server server = Server(av[1], av[2]);
 	server.start();
-	if (server._started)
-		std::cout << "Server started." << std::endl;
 	while(server._started)
-	{
 		server.loop();
-	}
 	return 0;
 }

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -8,7 +8,7 @@
 
 Server::Server() : _started(false), _sockfd(-1), _nb_clients(0),
 	_port(DEFAULT_PORT), _password(DEFAULT_PASSWORD), _ip_version(), _hints(),
-	_servinfo(NULL), _client_pfd_list(), _hostname("irc42.fr")
+	_servinfo(NULL), _client_pfd_list(), _hostname(SERVER_HOSTNAME)
 {
 	INFO((std::string)"no port provided, using default port " + DEFAULT_PORT);
 	INFO((std::string)"setting password to the default '" + DEFAULT_PASSWORD + "'");
@@ -18,14 +18,14 @@ Server::Server() : _started(false), _sockfd(-1), _nb_clients(0),
 	_hints.ai_flags = AI_PASSIVE;
 	if (getaddrinfo(NULL, _port.c_str(), &_hints, &_servinfo) != 0) {
 		ERROR("could not get the server connection details");
-		exit(1); // TODO throw an error ??
+		exit(1);
 	}
 	memset(&_client_pfd_list, 0, sizeof(_client_pfd_list) * MAX_CONNEXIONS);
 }
 
 Server::Server(std::string port, std::string password) : _started(false), 
 	_sockfd(-1), _nb_clients(0), _port(port), _password(password), _ip_version(),
-	_hints(), _servinfo(NULL), _client_pfd_list(), _hostname("irc42.fr")
+	_hints(), _servinfo(NULL), _client_pfd_list(), _hostname(SERVER_HOSTNAME)
 {
 	INFO((std::string)"using the given port " + port);
 	INFO((std::string)"using the given password '" + port + "'");
@@ -60,7 +60,7 @@ Server::~Server()
 {
 	this->stop();
 	freeaddrinfo(_servinfo);
-	INFO("Destroying server");
+	INFO("destroying server");
 }
 
 int	Server::stop()
@@ -268,4 +268,28 @@ const std::string& Server::get_password() const
 const std::string& Server::get_hostname() const
 {
 	return _hostname;
+}
+
+bool Server::is_valid_port(const std::string& port)
+{
+	if (port.empty())
+		return false;
+	for (std::string::const_iterator it = port.begin(); it != port.end(); it++) {
+		if (!isdigit(*it))
+			return false;
+	}
+	if (atoi(port.c_str()) < 1024 || atoi(port.c_str()) > 65535)
+		return false;
+	return true;
+}
+
+bool Server::is_valid_password(const std::string& password)
+{
+	if (password.size() < 1 || password.size() > 255)
+		return false;
+	for (std::string::const_iterator it = password.begin(); it != password.end(); it++) {
+		if (std::isspace(*it) || *it == '\0' || *it == ':')
+			return false;
+	}
+	return true;
 }


### PR DESCRIPTION
Close #26 

Now a password is mandatory, and added some additional verifications.
Password:
- Needs to have a size contained between 1 and 255
- Cannot contain any space characters, '\0' and ':'

Port:
- Cannot contain anything other than digits
- Cannot be bellow port 1024 and above port 65535